### PR TITLE
add GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: build
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build_and_publish:
+    name: build and publish package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-python@main
+        with:
+          python-version: '3.x'
+      - uses: actions/cache@main
+        with:
+          path: ${{ env.pythonLocation }}
+          key: build-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
+      - run: pip wheel . --no-deps -w dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: test
+
+on:
+  push:
+    paths:
+      - '**.py'
+      - '.github/workflows/test*.yml'
+      - 'pyproject.toml'
+  pull_request:
+    paths:
+      - '**.py'
+      - '.github/workflows/test*.yml'
+      - 'pyproject.toml'
+
+jobs:
+  style:
+    name: check code style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-python@main
+        with:
+          python-version: '3.x'
+      - uses: actions/cache@main
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: style-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
+      - run: pip install flake8 black
+      # stop the build if there are Python syntax errors or undefined names
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - run: black . --check
+  test:
+    needs: [ style ]
+    name: test Python ${{ matrix.python }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python: [ '3.9', '3.10' ]
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-python@main
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/cache@main
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
+      - run: pip install ".[test]" pytest-xdist
+      - run: pytest -n auto
+  test_with_coverage:
+    needs: [ style, test ]
+    name: test with code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/setup-python@main
+        with:
+          python-version: '3.x'
+      - uses: actions/cache@main
+        id: cache
+        with:
+          path: ${{ env.pythonLocation }}
+          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'setup.*') }}
+      - run: pip install ".[test]" pytest-cov pytest-xdist
+      - run: pytest -n auto --cov . --cov-report xml:coverage.xml
+      - run: coverage report -m
+      - uses: codecov/codecov-action@master
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**.py'
       - '.github/workflows/test*.yml'


### PR DESCRIPTION
this change adds a `test` workflow that triggers on every push, as well as a `build` workflow that builds the package and automatically publishes to PyPI upon publishing of a GitHub release (with corresponding tag).

[![image](https://user-images.githubusercontent.com/16024299/177186935-b40a79c3-9152-4010-8e13-f8f690467e97.png)](https://github.com/zacharyburnett/sparse-merkle-tree/actions/runs/2611151391)